### PR TITLE
Fixes user creation with invalid password

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.php]
+indent_style = space
+indent_size = 2

--- a/okta.php
+++ b/okta.php
@@ -217,7 +217,7 @@ if( ! class_exists( 'Okta' ) ) {
 
         $user_id = wp_insert_user ( array(
           'user_login' => $username,
-          'password' => wp_generate_password()
+          'user_pass'  => wp_generate_password()
         ) );
         if ( is_wp_error ( $user_id ) ) {
           die( $user_id->get_error_message() );


### PR DESCRIPTION
This fixes an error where the password was not correctly being passed to [`wp_insert_user`](https://developer.wordpress.org/reference/functions/wp_insert_user/). As per the documentation, the correct array key is `user_pass`, so `password` was throwing notice errors.

Also adding an [`editorconfig`](https://editorconfig.org/) file to inform IDEs of the existing code standard. Let me know if you want me to remove that.