### PR TITLE
Adjust login flow for custom user mapping

### DIFF
--- a/okta.php
+++ b/okta.php
@@ -28,9 +28,11 @@ if( ! class_exists( 'Okta' ) ) {
       if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
         require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
       }
-      $this->org_url = defined( 'OKTA_ORG_URL' ) ? OKTA_ORG_URL : ( is_plugin_active_for_network( 'okta/okta.php' ) ? get_site_option( 'okta_org_url' ) : get_option( 'okta_org_url' ) );
-      $this->client_id = defined( 'OKTA_CLIENT_ID' ) ? OKTA_CLIENT_ID : ( is_plugin_active_for_network( 'okta/okta.php' ) ? get_site_option( 'okta_client_id' ) : get_option( 'okta_client_id' ) );
-      $this->client_secret = defined( 'OKTA_CLIENT_SECRET' ) ? OKTA_CLIENT_SECRET : ( is_plugin_active_for_network( 'okta/okta.php' ) ? get_site_option( 'okta_client_secret' ) : get_option( 'okta_client_secret' ) );
+      $is_network = is_plugin_active_for_network( 'okta/okta.php' );
+
+      $this->org_url = defined( 'OKTA_ORG_URL' ) ? OKTA_ORG_URL : ( $is_network ? get_site_option( 'okta_org_url' ) : get_option( 'okta_org_url' ) );
+      $this->client_id = defined( 'OKTA_CLIENT_ID' ) ? OKTA_CLIENT_ID : ( $is_network ? get_site_option( 'okta_client_id' ) : get_option( 'okta_client_id' ) );
+      $this->client_secret = defined( 'OKTA_CLIENT_SECRET' ) ? OKTA_CLIENT_SECRET : ( $is_network ? get_site_option( 'okta_client_secret' ) : get_option( 'okta_client_secret' ) );
       $this->auth_secret = base64_encode( $this->client_id . ':' . $this->client_secret );
       $this->base_url = $this->org_url . '/oauth2/default/v1';
 
@@ -56,9 +58,12 @@ if( ! class_exists( 'Okta' ) ) {
       Admin menu
       */
 
-      add_action( 'admin_menu', array( $this, 'AdminMenu' ) );
-      add_action( 'network_admin_menu', array( $this, 'NetworkAdminMenu' ) );
-      add_action( 'network_admin_edit_okta', array ( $this, 'SettingsSave' ) );
+      if ( $is_network ){
+        add_action( 'network_admin_menu', array( $this, 'NetworkAdminMenu' ) );
+        add_action( 'network_admin_edit_okta', array ( $this, 'SettingsSave' ) );
+      }else{
+        add_action( 'admin_menu', array( $this, 'AdminMenu' ) );
+      }
 
       /*
       Deactivation

--- a/okta.php
+++ b/okta.php
@@ -443,10 +443,10 @@ if( ! class_exists( 'Okta' ) ) {
       Validate the request via nonce, referrer and capabilities
       */
 
-      if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'okta' ) || ! current_user_can( 'manage_network_options' ) ) {
+      if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'okta-options' ) || ! current_user_can( 'manage_network_options' ) ) {
         wp_die( 'No dice.' );
       }else{
-        check_admin_referer( 'okta' );
+        check_admin_referer( 'okta-options' );
       }
 
       /*
@@ -457,10 +457,10 @@ if( ! class_exists( 'Okta' ) ) {
         update_site_option( 'okta_org_url', esc_url_raw( $_POST['okta_org_url'], array( 'https' ) ) );
       }
       if ( isset( $_POST['okta_client_id'] ) ) {
-        update_site_option( 'okta_client_id', sanitize_key( $_POST['okta_client_id'] ) );
+        update_site_option( 'okta_client_id', sanitize_text_field( $_POST['okta_client_id'] ) );
       }
       if ( isset( $_POST['okta_client_secret'] ) ) {
-        update_site_option( 'okta_client_secret', sanitize_key( $_POST['okta_client_secret'] ) );
+        update_site_option( 'okta_client_secret', sanitize_text_field( $_POST['okta_client_secret'] ) );
       }
 
       /*

--- a/okta.php
+++ b/okta.php
@@ -293,7 +293,7 @@ if( ! class_exists( 'Okta' ) ) {
           'response_type' => 'code',
           'response_mode' => 'query',
           'scope' => 'openid profile',
-          'redirect_uri' => get_rest_url( is_multisite() ? get_current_site()->blog_id : null, 'okta/auth' ),
+          'redirect_uri' => get_rest_url( null, 'okta/auth' ),
           'state' => 'wordpress',
           'nonce' => wp_create_nonce( 'okta' )
         ]


### PR DESCRIPTION
This code does the following:

- Only displays the admin screen for either networks or individual sites instead of both. This fixes a case where the network-activated plugin cannot save settings in the per-site admin screen.
- Fixes bug where the nonce check for the site options screen was failing.
- Fixes bug where logging in on a multisite was redirecting users to the primary site only.
- Adds an additional check to ensure the Okta response is valid JSON and has an expected access token field.
- Creates a method `GetUser` to allow customization via filters of user ID validation and creation. This allows other plugins and themes to change mapping, such as matching via email instead of username, or changing the role or language of users based on criteria in the Okta user response.
